### PR TITLE
feat!: split config into settings and workspace.

### DIFF
--- a/src/lib/appStore.ts
+++ b/src/lib/appStore.ts
@@ -1,0 +1,5 @@
+import Store from 'electron-store'
+
+export const getSettingsStore = () => getStore('settings')
+export const getWorkspaceStore = () => getStore('workspace')
+export const getStore = (name: string) => new Store({ name })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,9 +1,9 @@
-import Store from 'electron-store'
 import { defaultSettings } from './defaults'
 import { SETTINGS } from './ipcChannels'
 import { BrowserWindow } from 'electron'
+import { getSettingsStore } from './appStore'
 
-const store = new Store()
+const store = getSettingsStore()
 
 export const getSettings = (): AppSettingsType => {
   return store.get('settings', defaultSettings) as AppSettingsType

--- a/src/main/ipcCollectionActions.ts
+++ b/src/main/ipcCollectionActions.ts
@@ -1,9 +1,9 @@
 import { dialog, ipcMain } from 'electron'
-import Store from 'electron-store'
 import CollectionImporter from '../lib/CollectionImporter'
 import { COLLECTIONS } from '../lib/ipcChannels'
+import { getWorkspaceStore } from '../lib/appStore'
 
-const store = new Store()
+const store = getWorkspaceStore()
 const COLLECTIONS_KEY = 'collections'
 
 ipcMain.on(COLLECTIONS.create, (event, collection: Collection) => {

--- a/src/main/ipcCookiesActions.ts
+++ b/src/main/ipcCookiesActions.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron'
-import Store from 'electron-store'
 import { COOKIES } from '../lib/ipcChannels'
+import { getWorkspaceStore } from '../lib/appStore'
 
-const store = new Store()
+const store = getWorkspaceStore()
 
 const COOKIES_KEY = 'cookies'
 

--- a/src/main/ipcEnvironmentActions.ts
+++ b/src/main/ipcEnvironmentActions.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron'
-import Store from 'electron-store'
 import { ENVIRONMENTS } from '../lib/ipcChannels'
+import { getWorkspaceStore } from '../lib/appStore'
 
-const store = new Store()
+const store = getWorkspaceStore()
 
 const ENVIRONMENTS_KEY = 'environments'
 

--- a/src/main/ipcTabsActions.ts
+++ b/src/main/ipcTabsActions.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron'
-import Store from 'electron-store'
 import { TABS } from '../lib/ipcChannels'
+import { getWorkspaceStore } from '../lib/appStore'
 
-const store = new Store()
+const store = getWorkspaceStore()
 
 ipcMain.on(TABS.update, (_, tabs: RequestTab[]) => {
   store.set('tabs', tabs)

--- a/src/main/migrations.ts
+++ b/src/main/migrations.ts
@@ -1,10 +1,45 @@
 import fs from 'fs'
 import * as path from 'path'
 import { app } from 'electron'
+import { defaultSettings } from '../lib/defaults'
 
-export function backupConfig() {
+export function backupConfig(previousVersion: string) {
   console.info('Backup config.json')
-  const configPath = path.join(app.getPath('userData'), 'config.json')
-  const configBakPath = path.join(app.getPath('userData'), 'config.bak.json')
+  const userDataPath = getUserDataPath()
+  const configPath = path.join(userDataPath, 'config.json')
+  const configBakPath = path.join(userDataPath, `config.bak-${previousVersion}.json`)
   fs.copyFileSync(configPath, configBakPath)
+}
+
+export function splitConfig() {
+  console.info('Split config.json: settings.json & workspace.json')
+  const userDataPath = getUserDataPath()
+  const configPath = path.join(userDataPath, 'config.json')
+  const config = getData(configPath)
+
+  const settings = {
+    settings: config?.settings || defaultSettings
+  }
+  const settingsPath = path.join(userDataPath, 'settings.json')
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2))
+
+  const workspace = {
+    tabs: config?.tabs || [],
+    environments: config?.environments || [],
+    collections: config?.collections || [],
+    cookies: config?.cookies || []
+  }
+  const workspacePath = path.join(userDataPath, 'workspace.json')
+  fs.writeFileSync(workspacePath, JSON.stringify(workspace, null, 2))
+  fs.unlinkSync(configPath)
+}
+
+const getUserDataPath = () => app.getPath('userData')
+
+function getData(filePath: string) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+  } catch (_) {
+    return null
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE: This commit introduces a new JSON configuration file format.
It is not backward-compatible, and rolling back to previous versions will require manual intervention.
Make sure to back up config.json before upgrading. (Note: the application will automatically create a backup as well)

Closes #244